### PR TITLE
Modernize project: edition 2024, drop thiserror/clap, refresh CI

### DIFF
--- a/.github/actions-rs/grcov.yml
+++ b/.github/actions-rs/grcov.yml
@@ -1,3 +1,0 @@
-ignore-not-existing: true
-ignore:
-  - "../*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
-# Based on https://github.com/actions-rs/meta/blob/master/recipes/quickstart.md
-
 name: CI
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   check:
@@ -13,20 +11,10 @@ jobs:
         toolchain: [stable, beta, nightly]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
-
-      - name: Install ${{ matrix.toolchain }} toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.toolchain }}
-          override: true
-
-      - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --all
+        uses: actions/checkout@v6
+      - run: rustup update ${{ matrix.toolchain }}
+      - run: rustup default ${{ matrix.toolchain }}
+      - run: cargo check --all
 
   test:
     name: Test Suite
@@ -36,90 +24,22 @@ jobs:
         toolchain: [stable, beta, nightly]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
-
-      - name: Install ${{ matrix.toolchain }} toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.toolchain }}
-          override: true
-
-      - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all
+        uses: actions/checkout@v6
+      - run: rustup update ${{ matrix.toolchain }}
+      - run: rustup default ${{ matrix.toolchain }}
+      - run: cargo test --all
 
   lints:
     name: Lints
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        toolchain: [stable, beta, nightly]
+        toolchain: [stable]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
-
-      - name: Install ${{ matrix.toolchain }} toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.toolchain }}
-          override: true
-          components: rustfmt, clippy
-
-      - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
-
-      - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all -- -D warnings
-
-  grcov:
-    name: Coverage
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
-
-      - name: Execute tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all
-        env:
-          CARGO_INCREMENTAL: 0
-          RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
-          RUSTDOCFLAGS: "-Cpanic=abort"
-
-      - name: Gather coverage data
-        id: coverage
-        uses: actions-rs/grcov@v0.1
-
-      - name: Coveralls upload
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel: true
-          path-to-lcov: ${{ steps.coverage.outputs.report }}
-
-  grcov_finalize:
-    runs-on: ubuntu-latest
-    needs: grcov
-    steps:
-      - name: Coveralls finalization
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel-finished: true
+        uses: actions/checkout@v6
+      - run: rustup update ${{ matrix.toolchain }}
+      - run: rustup default ${{ matrix.toolchain }}
+      - run: rustup component add rustfmt clippy
+      - run: cargo fmt --all -- --check
+      - run: cargo clippy --all -- -D warnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Create GitHub Release and Publish to crates.io
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  github-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - id: create-release
+        run: gh release create ${{ github.ref_name }} --title "${{ github.ref_name }}" --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+    - uses: actions/checkout@v6
+    - uses: rust-lang/crates-io-auth-action@v1
+      id: auth
+    - run: cargo publish
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,23 +1,17 @@
 [package]
 name = "erl_pp"
 version = "0.2.0"
-authors = ["Takeru Ohta <phjgt308@gmail.com>"]
+edition = "2024"
 description = "Erlang source code preprocessor"
 homepage = "https://github.com/sile/erl_pp"
 repository = "https://github.com/sile/erl_pp"
 readme = "README.md"
-keywords = ["erlang", "preprocessor"]
+categories = ["parser-implementations"]
 license = "MIT"
-edition = "2018"
-
-[badges]
-coveralls = {repository = "sile/erl_pp"}
 
 [dependencies]
-erl_tokenize = "0.4"
+erl_tokenize = "0.10"
 glob = "0.3"
-thiserror = "1"
 
 [dev-dependencies]
-anyhow = "1"
-clap = "2"
+noargs = "0.4"

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ erl_pp
 [![erl_pp](https://img.shields.io/crates/v/erl_pp.svg)](https://crates.io/crates/erl_pp)
 [![Documentation](https://docs.rs/erl_pp/badge.svg)](https://docs.rs/erl_pp)
 [![Actions Status](https://github.com/sile/erl_pp/workflows/CI/badge.svg)](https://github.com/sile/erl_pp/actions)
-[![Coverage Status](https://coveralls.io/repos/github/sile/erl_pp/badge.svg?branch=master)](https://coveralls.io/github/sile/erl_pp?branch=master)
-[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+![License](https://img.shields.io/crates/l/erl_pp)
 
 An Erlang source code preprocessor written in Rust.
 

--- a/examples/pp.rs
+++ b/examples/pp.rs
@@ -1,37 +1,59 @@
-use clap::{App, Arg};
 use erl_pp::{MacroDef, Preprocessor};
 use erl_tokenize::tokens::AtomToken;
 use erl_tokenize::{Lexer, Position, PositionRange};
 use std::env;
 use std::fs::File;
 use std::io::Read;
-use std::path::Path;
-use std::time::{Duration, Instant};
+use std::path::{Path, PathBuf};
+use std::time::Instant;
 
-fn main() -> anyhow::Result<()> {
-    let matches = App::new("pp")
-        .arg(Arg::with_name("SOURCE_FILE").index(1).required(true))
-        .arg(Arg::with_name("SILENT").long("silent"))
-        .arg(
-            Arg::with_name("CURRENT_DIR")
-                .long("current-dir")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("ERL_LIBS")
-                .long("libs")
-                .takes_value(true)
-                .multiple(true),
-        )
-        .get_matches();
-    let src_file = Path::new(matches.value_of("SOURCE_FILE").unwrap());
-    let silent = matches.is_present("SILENT");
-    if let Some(dir) = matches.value_of("CURRENT_DIR") {
+fn main() -> noargs::Result<()> {
+    let mut args = noargs::raw_args();
+    args.metadata_mut().app_name = env!("CARGO_PKG_NAME");
+    args.metadata_mut().app_description = env!("CARGO_PKG_DESCRIPTION");
+
+    if noargs::VERSION_FLAG.take(&mut args).is_present() {
+        println!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+        return Ok(());
+    }
+    noargs::HELP_FLAG.take_help(&mut args);
+
+    let silent = noargs::flag("silent")
+        .doc("Suppress per-token output")
+        .take(&mut args)
+        .is_present();
+    let current_dir: Option<PathBuf> = noargs::opt("current-dir")
+        .ty("DIR")
+        .doc("Change the current working directory before preprocessing")
+        .take(&mut args)
+        .present_and_then(|o| o.value().parse())?;
+    let mut libs: Vec<PathBuf> = Vec::new();
+    while let Some(lib) = noargs::opt("libs")
+        .ty("DIR")
+        .doc("Adds a code path entry used to resolve `include_lib` directives")
+        .take(&mut args)
+        .present_and_then(|o| o.value().parse::<PathBuf>())?
+    {
+        libs.push(lib);
+    }
+    let source_file: PathBuf = noargs::arg("<SOURCE_FILE>")
+        .doc("Erlang source file to preprocess")
+        .example("foo.erl")
+        .take(&mut args)
+        .then(|a| a.value().parse())?;
+
+    if let Some(help) = args.finish()? {
+        print!("{help}");
+        return Ok(());
+    }
+
+    if let Some(dir) = current_dir {
         env::set_current_dir(dir)?;
     }
 
+    let src_file: &Path = source_file.as_path();
     let mut src = String::new();
-    let mut file = File::open(&src_file).expect("Cannot open file");
+    let mut file = File::open(src_file).expect("Cannot open file");
     file.read_to_string(&mut src).expect("Cannot read file");
 
     let start_time = Instant::now();
@@ -41,18 +63,18 @@ fn main() -> anyhow::Result<()> {
     lexer.set_filepath(src_file.file_name().unwrap());
 
     let mut preprocessor = Preprocessor::new(lexer);
-    if let Some(libs) = matches.values_of("ERL_LIBS") {
-        for dir in libs {
-            preprocessor.code_paths_mut().push_back(dir.into());
-        }
+    for dir in libs {
+        preprocessor.code_paths_mut().push_back(dir);
     }
     preprocessor.macros_mut().insert(
         "MODULE".to_string(),
-        MacroDef::Dynamic(vec![AtomToken::from_value(
-            src_file.file_stem().unwrap().to_str().unwrap(),
-            Position::new(),
-        )
-        .into()]),
+        MacroDef::Dynamic(vec![
+            AtomToken::from_value(
+                src_file.file_stem().unwrap().to_str().unwrap(),
+                Position::new(),
+            )
+            .into(),
+        ]),
     );
 
     for result in preprocessor {
@@ -62,14 +84,7 @@ fn main() -> anyhow::Result<()> {
         }
         count += 1;
     }
-    println!("TOKEN COUNT: {}", count);
-    println!(
-        "ELAPSED: {:?} seconds",
-        to_seconds(Instant::now() - start_time)
-    );
+    println!("TOKEN COUNT: {count}");
+    println!("ELAPSED: {:?} seconds", start_time.elapsed().as_secs_f64());
     Ok(())
-}
-
-fn to_seconds(duration: Duration) -> f64 {
-    duration.as_secs() as f64 + f64::from(duration.subsec_nanos()) / 1_000_000_000.0
 }

--- a/src/directive.rs
+++ b/src/directive.rs
@@ -1,4 +1,4 @@
-use erl_tokenize::tokens::{AtomToken, SymbolToken};
+use erl_tokenize::tokens::SymbolToken;
 use erl_tokenize::values::Symbol;
 use erl_tokenize::{LexicalToken, Position, PositionRange};
 use std::fmt;
@@ -75,23 +75,28 @@ impl ReadFrom for Directive {
         T: Iterator<Item = erl_tokenize::Result<LexicalToken>>,
     {
         let _hyphen: SymbolToken = reader.read_expected(&Symbol::Hyphen)?;
-        let name: AtomToken = reader
-            .try_read()?
+        let name_token: LexicalToken = reader
+            .try_read_token()?
             .ok_or_else(|| Error::unexpected_token(_hyphen.clone().into(), "-{DIRECTIVE_NAME}"))?;
+        let name_text = match &name_token {
+            LexicalToken::Atom(t) => Some(t.value()),
+            LexicalToken::Keyword(t) => Some(t.text()),
+            _ => None,
+        };
 
-        reader.unread_token(name.clone().into());
+        reader.unread_token(name_token.clone());
         reader.unread_token(_hyphen.into());
-        match name.value() {
-            "include" => reader.read().map(Directive::Include),
-            "include_lib" => reader.read().map(Directive::IncludeLib),
-            "define" => reader.read().map(Directive::Define),
-            "undef" => reader.read().map(Directive::Undef),
-            "ifdef" => reader.read().map(Directive::Ifdef),
-            "ifndef" => reader.read().map(Directive::Ifndef),
-            "else" => reader.read().map(Directive::Else),
-            "endif" => reader.read().map(Directive::Endif),
-            "error" => reader.read().map(Directive::Error),
-            "warning" => reader.read().map(Directive::Warning),
+        match name_text {
+            Some("include") => reader.read().map(Directive::Include),
+            Some("include_lib") => reader.read().map(Directive::IncludeLib),
+            Some("define") => reader.read().map(Directive::Define),
+            Some("undef") => reader.read().map(Directive::Undef),
+            Some("ifdef") => reader.read().map(Directive::Ifdef),
+            Some("ifndef") => reader.read().map(Directive::Ifndef),
+            Some("else") => reader.read().map(Directive::Else),
+            Some("endif") => reader.read().map(Directive::Endif),
+            Some("error") => reader.read().map(Directive::Error),
+            Some("warning") => reader.read().map(Directive::Warning),
             _ => {
                 let _hyphen: SymbolToken = reader.read_expected(&Symbol::Hyphen)?;
                 Err(Error::unexpected_token(_hyphen.into(), "-{DIRECTIVE_NAME}"))

--- a/src/directives.rs
+++ b/src/directives.rs
@@ -1,16 +1,16 @@
 //! Macro directives.
-use erl_tokenize::tokens::{AtomToken, StringToken, SymbolToken};
-use erl_tokenize::values::Symbol;
+use erl_tokenize::tokens::{AtomToken, KeywordToken, StringToken, SymbolToken};
+use erl_tokenize::values::{Keyword, Symbol};
 use erl_tokenize::{LexicalToken, Position, PositionRange};
 use glob::glob;
 use std::collections::VecDeque;
 use std::fmt;
 use std::path::{Component, PathBuf};
 
+use crate::Result;
 use crate::token_reader::{ReadFrom, TokenReader};
 use crate::types::{MacroName, MacroVariables};
 use crate::util;
-use crate::Result;
 
 /// `include` directive.
 ///
@@ -88,7 +88,7 @@ impl IncludeLib {
         if let Some(Component::Normal(app_name)) = components.next() {
             let app_name = app_name
                 .to_str()
-                .ok_or_else(|| crate::Error::non_utf8_path(&app_name))?;
+                .ok_or_else(|| crate::Error::non_utf8_path(app_name))?;
             let pattern = format!("{}-*", app_name);
             'root: for root in code_paths.iter() {
                 let pattern = root.join(&pattern);
@@ -276,7 +276,7 @@ impl ReadFrom for Endif {
 #[allow(missing_docs)]
 pub struct Else {
     pub _hyphen: SymbolToken,
-    pub _else: AtomToken,
+    pub _else: KeywordToken,
     pub _dot: SymbolToken,
 }
 impl PositionRange for Else {
@@ -299,7 +299,7 @@ impl ReadFrom for Else {
     {
         Ok(Else {
             _hyphen: reader.read_expected(&Symbol::Hyphen)?,
-            _else: reader.read_expected("else")?,
+            _else: reader.read_expected(&Keyword::Else)?,
             _dot: reader.read_expected(&Symbol::Dot)?,
         })
     }
@@ -518,7 +518,7 @@ impl ReadFrom for Define {
                 let token = reader.read_token()?;
                 if token
                     .as_symbol_token()
-                    .map_or(false, |s| s.value() == Symbol::Dot)
+                    .is_some_and(|s| s.value() == Symbol::Dot)
                 {
                     return Err(crate::Error::unexpected_dot_in_macro_def(&token));
                 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,20 +5,18 @@ use erl_tokenize::{LexicalToken, Position, PositionRange};
 use std::path::{Path, PathBuf};
 
 /// Possible errors.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug)]
 #[non_exhaustive]
 #[allow(missing_docs)]
 #[allow(clippy::large_enum_variant)]
 pub enum Error {
     /// Unexpected token.
-    #[error("expected a {expected:?} token, but found {token:?}")]
     UnexpectedToken {
         token: LexicalToken,
         expected: String,
     },
 
     /// Include file error.
-    #[error("cannot include file: path={target_file_path:?}, reason={source}")]
     IncludeFileError {
         source: std::io::Error,
         directive_start: Position,
@@ -27,62 +25,49 @@ pub enum Error {
     },
 
     /// Missing a macro argument.
-    #[error("expected an macro argument before ',' ({position})")]
     MissingMacroArg { position: Position },
 
     /// Unbalanced parentheses.
-    #[error("unbalanced parentheses: open={open:?}, close={close:?}")]
     UnbalancedParen {
         open: Option<SymbolToken>,
         close: SymbolToken,
     },
 
     /// Unexpected EOF.
-    #[error("unexpected EOF")]
     UnexpectedEof,
 
     /// Cannot expand ?FILE macro.
-    #[error("cannot expand ?FILE macro ({macro_call:?})")]
     FileNotSet { macro_call: MacroCall },
 
     /// Undefined macro.
-    #[error("undefined macro: {macro_call:?}")]
     UndefinedMacro { macro_call: MacroCall },
 
     /// Undefined macro variable.
-    #[error("no such macro variable: {varname:?}")]
     UndefinedMacroVar { varname: String },
 
     /// Macro arguments mismatched.
-    #[error("macro arguments mismatched: def={macro_def:?}, call={macro_call:?}")]
     MacroArgsMismatched {
         macro_call: MacroCall,
         macro_def: MacroDef,
     },
 
     /// Non UTF-8 path.
-    #[error("cannot convert a path {path:?} to a UTF-8 string")]
     NonUtf8Path { path: PathBuf },
 
     /// Unexpected '.' in `-define` directive.
-    #[error("found unexpected '.' in `-define` directive ({position})")]
     UnexpectedDotInMacroDef { position: Position },
 
     /// Missing `-ifdef` or `-ifndef`.
-    #[error("missing `-ifdef` or `ifndef` directives")]
     MissingIfDirective { directive: Directive },
 
     /// Tokenize error.
-    #[error(transparent)]
-    TokenizeError(#[from] erl_tokenize::Error),
+    TokenizeError(erl_tokenize::Error),
 
     /// Glob pattern error.
-    #[error(transparent)]
-    GlobPatternError(#[from] glob::PatternError),
+    GlobPatternError(glob::PatternError),
 
     /// Glob error.
-    #[error(transparent)]
-    GlobError(#[from] glob::GlobError),
+    GlobError(glob::GlobError),
 }
 
 impl Error {
@@ -147,5 +132,91 @@ impl Error {
 
     pub(crate) fn missing_if_directive(directive: Directive) -> Self {
         Self::MissingIfDirective { directive }
+    }
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnexpectedToken { token, expected } => {
+                write!(f, "expected a {expected:?} token, but found {token:?}")
+            }
+            Self::IncludeFileError {
+                source,
+                target_file_path,
+                ..
+            } => {
+                write!(
+                    f,
+                    "cannot include file: path={target_file_path:?}, reason={source}"
+                )
+            }
+            Self::MissingMacroArg { position } => {
+                write!(f, "expected an macro argument before ',' ({position})")
+            }
+            Self::UnbalancedParen { open, close } => {
+                write!(f, "unbalanced parentheses: open={open:?}, close={close:?}")
+            }
+            Self::UnexpectedEof => write!(f, "unexpected EOF"),
+            Self::FileNotSet { macro_call } => {
+                write!(f, "cannot expand ?FILE macro ({macro_call:?})")
+            }
+            Self::UndefinedMacro { macro_call } => write!(f, "undefined macro: {macro_call:?}"),
+            Self::UndefinedMacroVar { varname } => {
+                write!(f, "no such macro variable: {varname:?}")
+            }
+            Self::MacroArgsMismatched {
+                macro_call,
+                macro_def,
+            } => write!(
+                f,
+                "macro arguments mismatched: def={macro_def:?}, call={macro_call:?}"
+            ),
+            Self::NonUtf8Path { path } => {
+                write!(f, "cannot convert a path {path:?} to a UTF-8 string")
+            }
+            Self::UnexpectedDotInMacroDef { position } => {
+                write!(
+                    f,
+                    "found unexpected '.' in `-define` directive ({position})"
+                )
+            }
+            Self::MissingIfDirective { .. } => {
+                write!(f, "missing `-ifdef` or `ifndef` directives")
+            }
+            Self::TokenizeError(e) => e.fmt(f),
+            Self::GlobPatternError(e) => e.fmt(f),
+            Self::GlobError(e) => e.fmt(f),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::IncludeFileError { source, .. } => Some(source),
+            Self::TokenizeError(e) => Some(e),
+            Self::GlobPatternError(e) => Some(e),
+            Self::GlobError(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<erl_tokenize::Error> for Error {
+    fn from(e: erl_tokenize::Error) -> Self {
+        Self::TokenizeError(e)
+    }
+}
+
+impl From<glob::PatternError> for Error {
+    fn from(e: glob::PatternError) -> Self {
+        Self::GlobPatternError(e)
+    }
+}
+
+impl From<glob::GlobError> for Error {
+    fn from(e: glob::GlobError) -> Self {
+        Self::GlobError(e)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@
 //! - [Erlang Reference Manual -- Preprocessor](http://erlang.org/doc/reference_manual/macros.html)
 //!
 #![warn(missing_docs)]
+#![allow(clippy::result_large_err)]
 pub use crate::directive::Directive;
 pub use crate::error::Error;
 pub use crate::macros::{MacroCall, MacroDef};

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -3,10 +3,10 @@ use erl_tokenize::values::Symbol;
 use erl_tokenize::{LexicalToken, Position, PositionRange};
 use std::fmt;
 
+use crate::Result;
 use crate::directives::Define;
 use crate::token_reader::{ReadFrom, TokenReader};
 use crate::types::{MacroArgs, MacroName};
-use crate::Result;
 
 /// Macro definition.
 #[derive(Debug, Clone)]

--- a/src/preprocessor.rs
+++ b/src/preprocessor.rs
@@ -72,18 +72,18 @@ where
             if let Some(token) = self.expanded_tokens.pop_front() {
                 return Ok(Some(token));
             }
-            if self.can_directive_start {
-                if let Some(d) = self.try_read_directive()? {
-                    self.directives.insert(d.start_position(), d);
-                    continue;
-                }
+            if self.can_directive_start
+                && let Some(d) = self.try_read_directive()?
+            {
+                self.directives.insert(d.start_position(), d);
+                continue;
             }
-            if !self.ignore() {
-                if let Some(m) = self.reader.try_read_macro_call(&self.macros)? {
-                    self.macro_calls.insert(m.start_position(), m.clone());
-                    self.expanded_tokens = self.expand_macro(m)?;
-                    continue;
-                }
+            if !self.ignore()
+                && let Some(m) = self.reader.try_read_macro_call(&self.macros)?
+            {
+                self.macro_calls.insert(m.start_position(), m.clone());
+                self.expanded_tokens = self.expand_macro(m)?;
+                continue;
             }
             if let Some(token) = self.reader.try_read_token()? {
                 if self.ignore() {
@@ -91,7 +91,7 @@ where
                 }
                 self.can_directive_start = token
                     .as_symbol_token()
-                    .map_or(false, |s| s.value() == Symbol::Dot);
+                    .is_some_and(|s| s.value() == Symbol::Dot);
                 return Ok(Some(token));
             } else {
                 break;
@@ -118,7 +118,7 @@ where
             }
             "LINE" => {
                 let line = call.start_position().line();
-                IntegerToken::from_value(line.into(), call.start_position()).into()
+                IntegerToken::from_value(line as i64, call.start_position()).into()
             }
             "MACHINE" => AtomToken::from_value("BEAM", call.start_position()).into(),
             _ => return Ok(None),
@@ -235,10 +235,8 @@ where
                     return Err(Error::missing_if_directive(directive));
                 }
             }
-            Directive::Endif(_) => {
-                if self.branches.pop().is_none() {
-                    return Err(Error::missing_if_directive(directive));
-                }
+            Directive::Endif(_) if self.branches.pop().is_none() => {
+                return Err(Error::missing_if_directive(directive));
             }
             _ => {}
         }

--- a/src/token_reader.rs
+++ b/src/token_reader.rs
@@ -1,5 +1,5 @@
-use erl_tokenize::tokens::{AtomToken, StringToken, SymbolToken, VariableToken};
-use erl_tokenize::values::Symbol;
+use erl_tokenize::tokens::{AtomToken, KeywordToken, StringToken, SymbolToken, VariableToken};
+use erl_tokenize::values::{Keyword, Symbol};
 use erl_tokenize::{Lexer, LexicalToken};
 use std::collections::{HashMap, VecDeque};
 use std::fmt::Debug;
@@ -56,7 +56,7 @@ where
             };
             if macros
                 .get(call.name.value())
-                .map_or(false, MacroDef::has_variables)
+                .is_some_and(MacroDef::has_variables)
             {
                 call.args = Some(self.read()?);
             }
@@ -211,6 +211,17 @@ impl ReadFrom for StringToken {
             .map_err(|token| Error::unexpected_token(token, "string"))
     }
 }
+impl ReadFrom for KeywordToken {
+    fn read_from<T>(reader: &mut TokenReader<T>) -> Result<Self>
+    where
+        T: Iterator<Item = erl_tokenize::Result<LexicalToken>>,
+    {
+        let token = reader.read_token()?;
+        token
+            .into_keyword_token()
+            .map_err(|token| Error::unexpected_token(token, "keyword"))
+    }
+}
 
 pub trait Expect {
     type Value: PartialEq + Debug + ?Sized;
@@ -224,6 +235,12 @@ impl Expect for AtomToken {
 }
 impl Expect for SymbolToken {
     type Value = Symbol;
+    fn expect(&self, expected: &Self::Value) -> bool {
+        self.value() == *expected
+    }
+}
+impl Expect for KeywordToken {
+    type Value = Keyword;
     fn expect(&self, expected: &Self::Value) -> bool {
         self.value() == *expected
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -87,7 +87,7 @@ pub struct MacroVariables {
 }
 impl MacroVariables {
     /// Returns an iterator which iterates over this variables.
-    pub fn iter(&self) -> ListIter<VariableToken> {
+    pub fn iter(&self) -> ListIter<'_, VariableToken> {
         self.list.iter()
     }
 
@@ -137,7 +137,7 @@ pub struct MacroArgs {
 }
 impl MacroArgs {
     /// Returns an iterator which iterates over this arguments.
-    pub fn iter(&self) -> ListIter<MacroArg> {
+    pub fn iter(&self) -> ListIter<'_, MacroArg> {
         self.list.iter()
     }
 
@@ -304,7 +304,7 @@ pub enum List<T> {
 }
 impl<T> List<T> {
     /// Returns an iterator which iterates over the elements in this list.
-    pub fn iter(&self) -> ListIter<T> {
+    pub fn iter(&self) -> ListIter<'_, T> {
         ListIter(ListIterInner::List(self))
     }
 }
@@ -350,18 +350,16 @@ impl<'a, T: 'a> Iterator for ListIterInner<'a, T> {
     type Item = &'a T;
     fn next(&mut self) -> Option<Self::Item> {
         match mem::replace(self, ListIterInner::End) {
-            ListIterInner::List(&List::Cons { ref head, ref tail }) => {
+            ListIterInner::List(List::Cons { head, tail }) => {
                 *self = ListIterInner::Tail(tail);
                 Some(head)
             }
-            ListIterInner::Tail(&Tail::Cons {
-                ref head, ref tail, ..
-            }) => {
+            ListIterInner::Tail(Tail::Cons { head, tail, .. }) => {
                 *self = ListIterInner::Tail(tail);
                 Some(head)
             }
-            ListIterInner::List(&List::Null)
-            | ListIterInner::Tail(&Tail::Null)
+            ListIterInner::List(List::Null)
+            | ListIterInner::Tail(Tail::Null)
             | ListIterInner::End => None,
         }
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,13 +6,12 @@ use std::path::{Path, PathBuf};
 pub fn substitute_path_variables<P: AsRef<Path>>(path: P) -> PathBuf {
     let mut new = PathBuf::new();
     for (i, c) in path.as_ref().components().enumerate() {
-        if let (0, Some(s)) = (i, c.as_os_str().to_str()) {
-            if s.as_bytes().get(0) == Some(&b'$') {
-                if let Ok(c) = env::var(s.split_at(1).1) {
-                    new.push(c);
-                    continue;
-                }
-            }
+        if let (0, Some(s)) = (i, c.as_os_str().to_str())
+            && s.as_bytes().first() == Some(&b'$')
+            && let Ok(c) = env::var(s.split_at(1).1)
+        {
+            new.push(c);
+            continue;
         }
         new.push(c.as_os_str());
     }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -156,7 +156,9 @@ fn macro_expansion_works() {
     let tokens = pp(src).collect::<Result<Vec<_>, _>>().unwrap();
     assert_eq!(
         tokens.iter().map(|t| t.text()).collect::<Vec<_>>(),
-        ["aaa", ".", "{", "bar", ",", "[", "1", ",", "2", "]", "}", ".", "bbb", ".",]
+        [
+            "aaa", ".", "{", "bar", ",", "[", "1", ",", "2", "]", "}", ".", "bbb", ".",
+        ]
     );
 
     let src = r#"-define(foo(A), {bar, ??A}).aaa.?foo([1,2]).bbb."#;


### PR DESCRIPTION
- Bump to Rust edition 2024 and update dependencies: `erl_tokenize` 0.4 → 0.10; drop `thiserror`, `anyhow`, `clap`; add `noargs` for the example. Handle new API (`else` is now a keyword, `IntegerToken::from_value` takes `i64`).
- Replace `thiserror` with hand-written `Display` / `Error` / `From` impls, and apply edition-2024 idioms (`let`-chains, `is_some_and`, explicit `'_` lifetimes, etc.).
- Rewrite `.github/workflows/ci.yml` to use `rustup` directly, add `release.yml` for tag-based crates.io publishing via OIDC, and drop the stale `actions-rs/grcov.yml` + Coveralls badge.

