### PR TITLE
Drop glob dependency in favor of std::fs::read_dir

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ license = "MIT"
 
 [dependencies]
 erl_tokenize = "0.10"
-glob = "0.3"
 
 [dev-dependencies]
 noargs = "0.4"

--- a/src/directives.rs
+++ b/src/directives.rs
@@ -2,10 +2,9 @@
 use erl_tokenize::tokens::{AtomToken, KeywordToken, StringToken, SymbolToken};
 use erl_tokenize::values::{Keyword, Symbol};
 use erl_tokenize::{LexicalToken, Position, PositionRange};
-use glob::glob;
 use std::collections::VecDeque;
 use std::fmt;
-use std::path::{Component, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use crate::Result;
 use crate::token_reader::{ReadFrom, TokenReader};
@@ -89,18 +88,13 @@ impl IncludeLib {
             let app_name = app_name
                 .to_str()
                 .ok_or_else(|| crate::Error::non_utf8_path(app_name))?;
-            let pattern = format!("{}-*", app_name);
-            'root: for root in code_paths.iter() {
-                let pattern = root.join(&pattern);
-                let pattern = pattern
-                    .to_str()
-                    .ok_or_else(|| crate::Error::non_utf8_path(&pattern))?;
-                if let Some(entry) = glob(pattern)?.next() {
-                    path = entry?;
+            for root in code_paths.iter() {
+                if let Some(entry) = find_app_dir(root, app_name)? {
+                    path = entry;
                     for c in components {
                         path.push(c.as_os_str());
                     }
-                    break 'root;
+                    break;
                 }
             }
         }
@@ -109,6 +103,23 @@ impl IncludeLib {
             .map_err(|e| crate::Error::include_file_error(e, self, path.clone()))?;
         Ok((path, text))
     }
+}
+fn find_app_dir(root: &Path, app_name: &str) -> Result<Option<PathBuf>> {
+    let prefix = format!("{app_name}-");
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return Ok(None);
+    };
+    let mut matches: Vec<PathBuf> = entries
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            e.file_name()
+                .to_str()
+                .is_some_and(|n| n.starts_with(&prefix))
+        })
+        .map(|e| e.path())
+        .collect();
+    matches.sort();
+    Ok(matches.into_iter().next())
 }
 impl PositionRange for IncludeLib {
     fn start_position(&self) -> Position {

--- a/src/error.rs
+++ b/src/error.rs
@@ -62,12 +62,6 @@ pub enum Error {
 
     /// Tokenize error.
     TokenizeError(erl_tokenize::Error),
-
-    /// Glob pattern error.
-    GlobPatternError(glob::PatternError),
-
-    /// Glob error.
-    GlobError(glob::GlobError),
 }
 
 impl Error {
@@ -185,8 +179,6 @@ impl std::fmt::Display for Error {
                 write!(f, "missing `-ifdef` or `ifndef` directives")
             }
             Self::TokenizeError(e) => e.fmt(f),
-            Self::GlobPatternError(e) => e.fmt(f),
-            Self::GlobError(e) => e.fmt(f),
         }
     }
 }
@@ -196,8 +188,6 @@ impl std::error::Error for Error {
         match self {
             Self::IncludeFileError { source, .. } => Some(source),
             Self::TokenizeError(e) => Some(e),
-            Self::GlobPatternError(e) => Some(e),
-            Self::GlobError(e) => Some(e),
             _ => None,
         }
     }
@@ -206,17 +196,5 @@ impl std::error::Error for Error {
 impl From<erl_tokenize::Error> for Error {
     fn from(e: erl_tokenize::Error) -> Self {
         Self::TokenizeError(e)
-    }
-}
-
-impl From<glob::PatternError> for Error {
-    fn from(e: glob::PatternError) -> Self {
-        Self::GlobPatternError(e)
-    }
-}
-
-impl From<glob::GlobError> for Error {
-    fn from(e: glob::GlobError) -> Self {
-        Self::GlobError(e)
     }
 }


### PR DESCRIPTION
- Replace the single use of `glob` in `include_lib` (pattern `{app}-*` under each code path) with a small `find_app_dir` helper using `std::fs::read_dir` + `starts_with`, sorted to preserve the previous lexicographic ordering.
- Remove `GlobPatternError` / `GlobError` variants and the corresponding `From` impls from `Error`.
- Drop `glob` from `[dependencies]`.

